### PR TITLE
feat: use field-data service when creating capture entries instead of…

### DIFF
--- a/microservice/config/config.example.js
+++ b/microservice/config/config.example.js
@@ -1,3 +1,5 @@
 exports.connectionString = "database connection string"
 exports.queueUrl = "https://sqs.eu-central-1.amazonaws.com/053061259712/treetracker-test-queue"
 exports.region = 'eu-central-1';
+exports.fieldDataURI = "<url to field data service>"
+exports.useFieldDataService = true

--- a/microservice/index.js
+++ b/microservice/index.js
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/node');
 const bearerToken = require('express-bearer-token');
 const bodyParser = require('body-parser');
 const http = require('http');
+const rp = require('request-promise-native');
 const pg = require('pg');
 const { Pool, Client } = require('pg');
 const path = require('path');
@@ -72,19 +73,32 @@ app.post('/tree', async (req, res) => {
       && req.body.uuid !== ""){
       duplicate  = await data.checkForExistingTree(req.body.uuid);
     }
+    console.log(`capture in field data schema for ${req.body.uuid} has duplicates ${duplicate === null}`);
     if(duplicate !== null){
       res.status(200).json({ duplicate });
     } else {
-      const tree = await data.createTree( user.id, req.body.device_identifier, req.body);
-      console.log("created tree " + tree.uuid);
-      res.status(201).json({ tree });
+       // translate to field-data capture api
+       const tree = req.body
+       const capture = { 
+        ...tree,
+        id: tree.uuid,
+        planter_id: tree.user_id
+      };
+      var options = {
+        method: 'POST',
+        uri: config.fieldDataURI + "captures",
+        body: capture,
+        json: true // Automatically stringifies the body to JSON
+      };
+
+      const fieldCapture = await rp(options);
+      console.log("created field data tree capture " + fieldCapture.id);
+      res.status(201).json({ fieldCapture });
     }
 });
 
 app.put('/device', async (req, res) => {
-
     const device = await data.upsertDevice(req.body);
-    console.log("upsert device " + device.id);
     res.status(200).json({ device });
 
 });


### PR DESCRIPTION
Use field-data service when creating capture entries instead of direct db writes to create tree entries in treetracker db.
