### PR TITLE
fix: incorrect id was used for planter_id when creating trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 database.json
 node_modules
-
+.env

--- a/cron/process-bulk-uploads.js
+++ b/cron/process-bulk-uploads.js
@@ -4,7 +4,6 @@ const http = require('http');
 const rp = require('request-promise-native');
 const { Pool, Client } = require('pg');
 
-console.log(Config);
 const pool = new Pool({
   connectionString: Config.connectionString
 });

--- a/cron/process-bulk-uploads.js
+++ b/cron/process-bulk-uploads.js
@@ -4,13 +4,10 @@ const http = require('http');
 const rp = require('request-promise-native');
 const { Pool, Client } = require('pg');
 
+console.log(Config);
 const pool = new Pool({
   connectionString: Config.connectionString
 });
-
-//const Sentry = require('@sentry/node');
-//Sentry.init({ dsn: Config.sentryDSN });
-
 
 (async () => {
 
@@ -132,7 +129,6 @@ const pool = new Pool({
 })().catch(e => {
 
   console.log(e);
-  Sentry.captureException(e);
   pool.end();
 
   console.log('notify-slack-reports done with catch');

--- a/microservice/.env.example
+++ b/microservice/.env.example
@@ -1,4 +1,4 @@
 DB_URL="db connection url"
 FIELD_DATA_URL="http://dev-k8s.treetracker.org/field-data/captures"
 SQS_URL="https://sqs.eu-central-1.amazonaws.com/053061259712/treetracker-test-queue"
-USE_FIELD_DATA_SERVICE=true
+USE_FIELD_DATA_SERVICE="false"

--- a/microservice/index.js
+++ b/microservice/index.js
@@ -83,7 +83,7 @@ app.post('/tree', async (req, res) => {
         const capture = { 
           ...tree,
           id: tree.uuid,
-          planter_id: tree.user_id
+          planter_id: user.id
         };
         var options = {
           method: 'POST',


### PR DESCRIPTION
While refactoring field data service I happened to realize that the user_id from `tree` (bulk-pack) payload was used to populate the `planter_id` in trees table. It should have been the `user.id` that is retrieved by looking up `planter_identifier` instead.

This fix is ensure correct code is there  in the repo just in case we end up deploying this to production. I have fixed the bulk-pack-transformer (the k8 cluster equivalent).